### PR TITLE
fix humidity for EEP A5-04-01/-02 (wrong offset)

### DIFF
--- a/src/main/java/uk/co/_4ng/enocean/eep/eep26/profiles/A5/A504/A504TemperatureAndHumidityMessage.java
+++ b/src/main/java/uk/co/_4ng/enocean/eep/eep26/profiles/A5/A504/A504TemperatureAndHumidityMessage.java
@@ -34,15 +34,16 @@ class A504TemperatureAndHumidityMessage {
      */
     A504TemperatureAndHumidityMessage(byte data[], Class clazz) {
 
-        // humidity data has offset 0
-        humidity = 0x00FF & data[0];
-
         if (clazz.equals(A50403.class)) {
             // temperature data has offset 14 and is 10 bits
             int temperature = ((data[1] & 0xc0) << 2) + data[2];
             this.temperature = temperature & 0x3ff;
+            // humidity data has offset 0
+            humidity = 0x00FF & data[0];
         }
         else {
+            // humidity data has offset 1
+            humidity = 0x00FF & data[1];
             // transform into a positive integer
             temperature = 0x00FF & data[2];
         }


### PR DESCRIPTION
For profiles A5-04-01/-02, the humidity is actually at offset 1, only for -03 its at offset 0.